### PR TITLE
Create .gitattributes so we get CRLF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Declare files that will always have CRLF line endings on checkout.
+*.bat eol=crlf
+*.ps1 eol=crlf
+*.txt eol=crlf
+*.vbs eol=crlf
+*.xml eol=crlf
+*.properties eol=crlf
+*.sites eol=crlf
+*.config eol=crlf
+*.h eol=crlf
+*.reg eol=crlf
+*.cfg eol=crlf
+*.ini eol=crlf
+
+
+# Denote all files that are truly binary and should not be modified.
+*.exe binary


### PR DESCRIPTION
I just copied contents of the equivalent file in the tron repo. This will make sure that certain files will always have CRLF Line endings. [More info
](https://help.github.com/articles/dealing-with-line-endings/)
I had some problems with the pingup script recently, it wasn't pinging more than once: `The system cannot find the batch label specified - start`
[Turns out](https://stackoverflow.com/a/232674) that this is caused by LF line endings if you downloaded the file from github instead of copying it and pasting it.